### PR TITLE
Fix Tracing for Recent Nvidia Drivers

### DIFF
--- a/mmt/mmt_trace.c
+++ b/mmt/mmt_trace.c
@@ -843,6 +843,8 @@ void mmt_post_syscall(ThreadId tid, UInt syscallno, UWord *args,
 	}
 	else if (syscallno == __NR_open)
 		post_open(tid, args, nArgs, res);
+	else if (syscallno == __NR_openat)
+		post_open(tid, args+1, nArgs-1, res);
 	else if (syscallno == __NR_close)
 		post_close(tid, args, nArgs, res);
 	else if (syscallno == __NR_mmap)


### PR DESCRIPTION
Fixes tracing for more recent Nvidia drivers which seem to use openat() in place of open() for /dev/nvidia*.

Thanks to @imirkin for helping to find it.